### PR TITLE
tetgen 1.5.1 (migrated from homebrew-science)

### DIFF
--- a/Formula/tetgen.rb
+++ b/Formula/tetgen.rb
@@ -1,0 +1,46 @@
+class Tetgen < Formula
+  desc "Quality Tetrahedral Mesh Generator and a 3D Delaunay Triangulator"
+  homepage "http://tetgen.org/"
+  url "http://www.tetgen.org/1.5/src/tetgen1.5.1.tar.gz"
+  sha256 "e46a4434a3e7c00044c8f4f167e18b6f4a85be7d22838c8f948ce8cc8c01b850"
+
+  depends_on "cmake" => :build
+
+  resource "manual" do
+    url "http://www.tetgen.org/1.5/doc/manual/manual.pdf"
+    sha256 "ce71e755c33dc518b1a3bc376fb860c0659e7e14b18e4d9798edcbda05a24eca"
+  end
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make"
+      bin.install "tetgen"
+      lib.install "libtet.a"
+      include.install buildpath/"tetgen.h"
+      resource("manual").stage do
+        doc.install "manual.pdf"
+      end
+      pkgshare.install buildpath/"example.poly"
+    end
+  end
+
+  test do
+    cp pkgshare/"example.poly", testpath
+    output = shell_output("#{bin}/tetgen -pq1.2V example.poly")
+    assert_match /[Ss]tatistics/, output, "Missing statistics in output"
+    assert_match /[Hh]istogram/, output, "Missing histogram in output"
+    assert_match /seconds/, output, "Missing timings in output"
+    outfile_suffixes = %w[node ele face edge]
+    outfile_suffixes.each do |suff|
+      assert_predicate testpath/"example.1.#{suff}", :exist?
+      rm testpath/"example.1.#{suff}"
+    end
+    cp testpath/"example.poly", testpath/"example.node"
+    system "#{bin}/tetgen", testpath/"example.node"
+    outfile_suffixes -= ["edge"]
+    outfile_suffixes.each do |suff|
+      assert_predicate testpath/"example.1.#{suff}", :exist?
+    end
+  end
+end


### PR DESCRIPTION
 - Better tests added
 - Transition to using CMake build system
 - Install manual & headers in addition to library and binary