### PR TITLE
Add [skip bottles]

### DIFF
--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   upload-bottles:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip bottles]')"
     container:
       image: homebrew/ubuntu16.04:master
     env:


### PR DESCRIPTION
This should allow the `upload-bottles` workflow to be skipped if the commit message contains `[skip bottles]`