### PR TITLE
Update brewsci-r.rb

### DIFF
--- a/Formula/brewsci-r.rb
+++ b/Formula/brewsci-r.rb
@@ -22,7 +22,7 @@ class BrewsciR < Formula
   depends_on "pcre"
   depends_on "readline"
   depends_on "xz"
-  depends_on java: :optional
+  depends_on "openjdk@8"
 
   unless OS.mac?
     depends_on "cairo"


### PR DESCRIPTION
Unable to install brewsci-mumps due to error in associated package, brewsci-r. 

I think this pr should fix it **but** I seem to be going round in circles. I have installed other formulae from this repo (eg Tetgen) but Brew insists on going back to tap the original brewsci/num repo and then failing on brewsci-r - which is a package I don't even want to install from here (I have it already).

```
$brew tap
gasman2014/num
homebrew/cask
homebrew/core

$brew install gasman2014/num/brewsci-mumps
==> Installing brewsci-mumps from gasman2014/num
==> Tapping brewsci/num                                          <------------- WHY?????
Cloning into '/usr/local/Homebrew/Library/Taps/brewsci/homebrew-num'...
remote: Enumerating objects: 69, done.
remote: Counting objects: 100% (69/69), done.
remote: Compressing objects: 100% (49/49), done.
remote: Total 470 (delta 43), reused 34 (delta 20), pack-reused 401
Receiving objects: 100% (470/470), 98.92 KiB | 1.87 MiB/s, done.
Resolving deltas: 100% (215/215), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/brewsci/homebrew-num/Formula/brewsci-r.rb
brewsci-r: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the brewsci/num tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/brewsci/homebrew-num/Formula/brewsci-r.rb:25
```